### PR TITLE
Support current TestingBot service constructor signature

### DIFF
--- a/lib/plugin/wdio.js
+++ b/lib/plugin/wdio.js
@@ -110,7 +110,7 @@ module.exports = (config) => {
         } else {
           if (Launcher.name === 'TestingBotLauncher' && Launcher.constructor.length === 1) {
             options = {
-              tbTunnel: tbTunnel,
+              tbTunnel: config.tbTunnel,
               tbTunnelOpts: config.tbTunnelOpts,
             };
           }

--- a/lib/plugin/wdio.js
+++ b/lib/plugin/wdio.js
@@ -103,12 +103,20 @@ module.exports = (config) => {
     if (Service) {
       if (Service.launcher && typeof Service.launcher === 'function') {
         const Launcher = Service.launcher;
-
+        let options;
         const version = JSON.parse(fs.readFileSync(path.join(require.resolve('webdriverio'), '/../../', 'package.json')).toString()).version;
         if (version.indexOf('5') === 0) {
           launchers.push(new Launcher(config));
         } else {
-          const options = { logPath: global.output_dir, installArgs: seleniumInstallArgs, args: seleniumArgs };
+          if (Launcher.name === 'TestingBotLauncher' && Launcher.constructor.length === 1) {
+            options = {
+              tbTunnel: tbTunnel,
+              tbTunnelOpts: config.tbTunnelOpts,
+            };
+          }
+          else {
+            options = { logPath: global.output_dir, installArgs: seleniumInstallArgs, args: seleniumArgs };
+          }
           launchers.push(new Launcher(options, [config.capabilities], config));
         }
       }


### PR DESCRIPTION
Current signature just takes `options` (similar to "webdriverio v5 style"). The tunnel boolean and opts object are ignored by the current calling pattern.

## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
